### PR TITLE
Fix behaviour behind load balancer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ luac.out
 *.x86_64
 *.hex
 
+/.idea/

--- a/src/handler.lua
+++ b/src/handler.lua
@@ -14,7 +14,7 @@ end
 function HttpFilterHandler:access(conf)
   HttpFilterHandler.super.access(self)
 
-  if ngx.var.https ~= "on" then
+  if ngx.var.https ~= "on" and ngx.var.http_x_forwarded_proto ~= "https" then
     local matches_exclude_pattern = conf.exclude_uri_pattern and string.find(ngx.var.request_uri, conf.exclude_uri_pattern)
     if not matches_exclude_pattern then
       return ngx.redirect("https://" .. ngx.var.host .. ngx.var.request_uri, ngx.HTTP_MOVED_PERMANENTLY)


### PR DESCRIPTION
If Kong is behind a load balancer a check for https is not enough because it's always off. We should additionally check for the header value in X-Forwarded-Proto. We only redirect if not "https".
(see HappyValleyIO/kong-http-to-https-redirect#4).
